### PR TITLE
Fix link to PFPL - Mention PFPL editions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ read closely on a second pass.
     but I think PFPL does a better job explaining the foundations it
     works from and then covers more topics I find interesting.
 
-    * [Online copy](http://www.cs.cmu.edu/~rwh/plbook/2nded.pdf)
-    * [Dead-tree copy](http://www.amazon.com/Practical-Foundations-Programming-Languages-Professor/dp/1107029570/ref=sr_1_1?ie=UTF8&qid=1439346858&sr=8-1&keywords=practical+foundations+for+programming+languages)
+    * [Online copy (2nd Edition Preview)](http://www.cs.cmu.edu/~rwh/pfpl/2nded.pdf)
+    * [Dead-tree copy (2nd Edition)](https://www.amazon.com/Practical-Foundations-Programming-Languages-Robert/dp/1107150302)
+
 
  - Types and Programming Languages (TAPL)
 


### PR DESCRIPTION
PFPL online copy is a preview of the second edition, while the dead tree copy is the 1st edition.
